### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/src/memory-bank/content-processor.ts
+++ b/src/memory-bank/content-processor.ts
@@ -47,7 +47,12 @@ export class ContentProcessor implements IContentProcessor {
     try {
       // Regex to match HTML comments: <!-- ... -->
       // [\s\S]*? matches any character (including newline) non-greedily
-      const processed = content.replace(/<!--[\s\S]*?-->/g, '');
+      let previous;
+      let processed = content;
+      do {
+        previous = processed;
+        processed = processed.replace(/<!--[\s\S]*?-->/g, '');
+      } while (processed !== previous);
       return Result.ok(processed);
     } catch (error) {
       return this._wrapProcessingError(


### PR DESCRIPTION
Potential fix for [https://github.com/Hive-Academy/roocode-generator/security/code-scanning/3](https://github.com/Hive-Academy/roocode-generator/security/code-scanning/3)

To fix the issue, we need to ensure that all instances of HTML comments are removed, even if they are nested or overlapping. A robust approach is to repeatedly apply the regular expression replacement until no more matches are found. This ensures that all HTML comments are completely stripped from the input. The fix involves modifying the `stripHtmlComments` method to use a loop that continues replacing matches until the input string no longer changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
